### PR TITLE
Fix BIS3 examples to be PEPPOL-compliant

### DIFF
--- a/ubl/examples/BIS3_Invoice_negativ.XML
+++ b/ubl/examples/BIS3_Invoice_negativ.XML
@@ -27,9 +27,9 @@
   </cac:ContractDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">12345678</cbc:EndpointID>
+      <cbc:EndpointID schemeID="0184">DK12345678</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="0184">12345678</cbc:ID>
+        <cbc:ID schemeID="0184">DK12345678</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>Company A</cbc:Name>
@@ -50,15 +50,15 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Company A</cbc:RegistrationName>
-        <cbc:CompanyID schemeID="0184">12345678</cbc:CompanyID>
+        <cbc:CompanyID schemeID="0184">DK12345678</cbc:CompanyID>
       </cac:PartyLegalEntity>
     </cac:Party>
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">87654321</cbc:EndpointID>
+      <cbc:EndpointID schemeID="0184">DK87654321</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="0184">87654321</cbc:ID>
+        <cbc:ID schemeID="0184">DK87654321</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>Company B</cbc:Name>
@@ -79,7 +79,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Company B</cbc:RegistrationName>
-        <cbc:CompanyID schemeID="0184">87654321</cbc:CompanyID>
+        <cbc:CompanyID schemeID="0184">DK87654321</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>n/a</cbc:Name>

--- a/ubl/examples/BIS3_Invoice_positive.XML
+++ b/ubl/examples/BIS3_Invoice_positive.XML
@@ -27,9 +27,9 @@
   </cac:ContractDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">12345678</cbc:EndpointID>
+      <cbc:EndpointID schemeID="0184">DK12345678</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="0184">12345678</cbc:ID>
+        <cbc:ID schemeID="0184">DK12345678</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>Company A</cbc:Name>
@@ -50,15 +50,15 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Company A</cbc:RegistrationName>
-        <cbc:CompanyID schemeID="0184">12345678</cbc:CompanyID>
+        <cbc:CompanyID schemeID="0184">DK12345678</cbc:CompanyID>
       </cac:PartyLegalEntity>
     </cac:Party>
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">87654321</cbc:EndpointID>
+      <cbc:EndpointID schemeID="0184">DK87654321</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="0184">87654321</cbc:ID>
+        <cbc:ID schemeID="0184">DK87654321</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>Company B</cbc:Name>
@@ -79,7 +79,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Company B</cbc:RegistrationName>
-        <cbc:CompanyID schemeID="0184">87654321</cbc:CompanyID>
+        <cbc:CompanyID schemeID="0184">DK87654321</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>n/a</cbc:Name>


### PR DESCRIPTION
It looks like these example files are meant to be PEPPOL BIS files:
```
./ubl/examples/BIS3_Invoice_positive.XML
./ubl/examples/BIS3_Invoice_negativ.XML
```

However, they are not valid according to the PEPPOL UBL validation rules. Tested with [peppol-py](https://github.com/iterasdev/peppol-py):
```
python -m peppol_py validate --document /tmp/eInvoicing-EN16931/ubl/examples/BIS3_Invoice_negativ.XML 
{'text': 'Danish organization number (CVR) MUST be stated in the correct format.', 'code': 'PEPPOL-COMMON-R042', 'severity': 'fatal', 'test': "(string-length(text()) = 10) and (substring(text(), 1, 2) = 'DK') and (string-length(translate(substring(text(), 3, 8), '1234567890', '')) = 0)", 'location': '/Invoice[1]/AccountingSupplierParty[1]/Party[1]/EndpointID[1]'}
{'text': 'Danish organization number (CVR) MUST be stated in the correct format.', 'code': 'PEPPOL-COMMON-R042', 'severity': 'fatal', 'test': "(string-length(text()) = 10) and (substring(text(), 1, 2) = 'DK') and (string-length(translate(substring(text(), 3, 8), '1234567890', '')) = 0)", 'location': '/Invoice[1]/AccountingSupplierParty[1]/Party[1]/PartyIdentification[1]/ID[1]'}
{'text': 'Danish organization number (CVR) MUST be stated in the correct format.', 'code': 'PEPPOL-COMMON-R042', 'severity': 'fatal', 'test': "(string-length(text()) = 10) and (substring(text(), 1, 2) = 'DK') and (string-length(translate(substring(text(), 3, 8), '1234567890', '')) = 0)", 'location': '/Invoice[1]/AccountingSupplierParty[1]/Party[1]/PartyLegalEntity[1]/CompanyID[1]'}
{'text': 'Danish organization number (CVR) MUST be stated in the correct format.', 'code': 'PEPPOL-COMMON-R042', 'severity': 'fatal', 'test': "(string-length(text()) = 10) and (substring(text(), 1, 2) = 'DK') and (string-length(translate(substring(text(), 3, 8), '1234567890', '')) = 0)", 'location': '/Invoice[1]/AccountingCustomerParty[1]/Party[1]/EndpointID[1]'}
{'text': 'Danish organization number (CVR) MUST be stated in the correct format.', 'code': 'PEPPOL-COMMON-R042', 'severity': 'fatal', 'test': "(string-length(text()) = 10) and (substring(text(), 1, 2) = 'DK') and (string-length(translate(substring(text(), 3, 8), '1234567890', '')) = 0)", 'location': '/Invoice[1]/AccountingCustomerParty[1]/Party[1]/PartyIdentification[1]/ID[1]'}
{'text': 'Danish organization number (CVR) MUST be stated in the correct format.', 'code': 'PEPPOL-COMMON-R042', 'severity': 'fatal', 'test': "(string-length(text()) = 10) and (substring(text(), 1, 2) = 'DK') and (string-length(translate(substring(text(), 3, 8), '1234567890', '')) = 0)", 'location': '/Invoice[1]/AccountingCustomerParty[1]/Party[1]/PartyLegalEntity[1]/CompanyID[1]'}
```

The [PEPPOL-COMMON-R042](https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-peppol/PEPPOL-COMMON-R042/) rules expect that Danish company identifiers (CVRs) start with DK. Therefore, e.g., 12345678 must become DK12345678.