### PR TITLE
Remove rules CII-SR-465 and CII-SR-466.

### DIFF
--- a/cii/schematron/CII/EN16931-CII-syntax.sch
+++ b/cii/schematron/CII/EN16931-CII-syntax.sch
@@ -635,8 +635,6 @@
 	<param name="CII-SR-460" value="count(ram:BuyerTradeParty/ram:URIUniversalCommunication) &lt;= 1"/>
 	<param name="CII-SR-461" value="count(ram:ApplicableTradeTax/ram:TaxPointDate) &lt;= 1"/>
 	<param name="CII-SR-462" value="count(//ram:ApplicableTradeTax/ram:DueDateTypeCode) = 0 or count(distinct-values(//ram:ApplicableTradeTax/ram:DueDateTypeCode)) = 1"/>
-	<param name="CII-SR-465" value="not(ram:SellerTradeParty/ram:DefinedTradeContact/ram:PersonName and ram:SellerTradeParty/ram:DefinedTradeContact/ram:DepartmentName)"/>
-	<param name="CII-SR-466" value="not(ram:BuyerTradeParty/ram:DefinedTradeContact/ram:PersonName and ram:BuyerTradeParty/ram:DefinedTradeContact/ram:DepartmentName)"/>
 	
 	<!-- Invoice -->
 	<param name="CII-SR-438" value="not(ram:ValuationBreakdownStatement)"/>

--- a/cii/schematron/abstract/EN16931-CII-syntax.sch
+++ b/cii/schematron/abstract/EN16931-CII-syntax.sch
@@ -383,8 +383,6 @@
 		<assert test="$CII-SR-458" flag="warning" id="CII-SR-458">[CII-SR-458] - IssuerAssignedID with TypeCode 130 should exist maximum once</assert>
 		<assert test="$CII-SR-459" flag="fatal" id="CII-SR-459">[CII-SR-459] - SellerTradeParty URIUniversalCommunication should exist maximum once</assert>
 		<assert test="$CII-SR-460" flag="fatal" id="CII-SR-460">[CII-SR-460] - BuyerTradeParty URIUniversalCommunication should exist maximum once</assert>
-		<assert test="$CII-SR-465" flag="warning" id="CII-SR-465">[CII-SR-465] - Only one BT-41 element is allowed on an invoice.</assert>
-		<assert test="$CII-SR-466" flag="warning" id="CII-SR-466">[CII-SR-466] - Only one BT-56 element is allowed on an invoice.</assert>
 	</rule>
 	<rule context="$ApplicableHeaderTradeDelivery">
 		<assert test="$CII-SR-308" flag="warning" id="CII-SR-308">[CII-SR-308] - RelatedSupplyChainConsignment should not be present</assert>

--- a/cii/schematron/preprocessed/EN16931-CII-validation-preprocessed.sch
+++ b/cii/schematron/preprocessed/EN16931-CII-validation-preprocessed.sch
@@ -687,8 +687,6 @@
       <assert id="CII-SR-458" flag="warning" test="( count(ram:AdditionalReferencedDocument[ram:TypeCode='130'])  &lt;= 1)">[CII-SR-458] - IssuerAssignedID with TypeCode 130 should exist maximum once</assert>
       <assert id="CII-SR-459" flag="fatal" test="count(ram:SellerTradeParty/ram:URIUniversalCommunication) &lt;= 1">[CII-SR-459] - SellerTradeParty URIUniversalCommunication should exist maximum once</assert>
       <assert id="CII-SR-460" flag="fatal" test="count(ram:BuyerTradeParty/ram:URIUniversalCommunication) &lt;= 1">[CII-SR-460] - BuyerTradeParty URIUniversalCommunication should exist maximum once</assert>
-      <assert id="CII-SR-465" flag="warning" test="not(ram:SellerTradeParty/ram:DefinedTradeContact/ram:PersonName and ram:SellerTradeParty/ram:DefinedTradeContact/ram:DepartmentName)">[CII-SR-465] - Only one BT-41 element is allowed on an invoice.</assert>
-      <assert id="CII-SR-466" flag="warning" test="not(ram:BuyerTradeParty/ram:DefinedTradeContact/ram:PersonName and ram:BuyerTradeParty/ram:DefinedTradeContact/ram:DepartmentName)">[CII-SR-466] - Only one BT-56 element is allowed on an invoice.</assert>
     </rule>
     <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery">
       <assert id="CII-SR-308" flag="warning" test="not(ram:RelatedSupplyChainConsignment)">[CII-SR-308] - RelatedSupplyChainConsignment should not be present</assert>

--- a/cii/xslt/EN16931-CII-validation.xslt
+++ b/cii/xslt/EN16931-CII-validation.xslt
@@ -8428,36 +8428,6 @@
         </svrl:failed-assert>
       </xsl:otherwise>
     </xsl:choose>
-
-		<!--ASSERT -->
-<xsl:choose>
-      <xsl:when test="not(ram:SellerTradeParty/ram:DefinedTradeContact/ram:PersonName and ram:SellerTradeParty/ram:DefinedTradeContact/ram:DepartmentName)" />
-      <xsl:otherwise>
-        <svrl:failed-assert test="not(ram:SellerTradeParty/ram:DefinedTradeContact/ram:PersonName and ram:SellerTradeParty/ram:DefinedTradeContact/ram:DepartmentName)">
-          <xsl:attribute name="id">CII-SR-465</xsl:attribute>
-          <xsl:attribute name="flag">warning</xsl:attribute>
-          <xsl:attribute name="location">
-            <xsl:apply-templates mode="schematron-select-full-path" select="." />
-          </xsl:attribute>
-          <svrl:text>[CII-SR-465] - Only one BT-41 element is allowed on an invoice.</svrl:text>
-        </svrl:failed-assert>
-      </xsl:otherwise>
-    </xsl:choose>
-
-		<!--ASSERT -->
-<xsl:choose>
-      <xsl:when test="not(ram:BuyerTradeParty/ram:DefinedTradeContact/ram:PersonName and ram:BuyerTradeParty/ram:DefinedTradeContact/ram:DepartmentName)" />
-      <xsl:otherwise>
-        <svrl:failed-assert test="not(ram:BuyerTradeParty/ram:DefinedTradeContact/ram:PersonName and ram:BuyerTradeParty/ram:DefinedTradeContact/ram:DepartmentName)">
-          <xsl:attribute name="id">CII-SR-466</xsl:attribute>
-          <xsl:attribute name="flag">warning</xsl:attribute>
-          <xsl:attribute name="location">
-            <xsl:apply-templates mode="schematron-select-full-path" select="." />
-          </xsl:attribute>
-          <svrl:text>[CII-SR-466] - Only one BT-56 element is allowed on an invoice.</svrl:text>
-        </svrl:failed-assert>
-      </xsl:otherwise>
-    </xsl:choose>
     <xsl:apply-templates mode="M11" select="@*|*" />
   </xsl:template>
 


### PR DESCRIPTION
It's perfectly reasonable to specify both person and department names.

Rolling out those two rules will break a lot of formerly valid invoices and cause a massive negative impact on electronic invoicing.

As mentioned by oriol in issue #448 (*not* #488 referenced in the commit message for bf3a7d8d7137bec0c90f35d0fad42e30128fa2fd), the problem with the cardinality for BT-41 and BT-56 isn't something to be fixed in the schematron rules.

This reverts commit bf3a7d8d7137bec0c90f35d0fad42e30128fa2fd.